### PR TITLE
Added vscript.dll to downloader and removed broken patcher for vscript.dll

### DIFF
--- a/CS2Installer/download.cpp
+++ b/CS2Installer/download.cpp
@@ -241,12 +241,13 @@ void Downloader::DownloadCS2() {
 
 void Downloader::DownloadMods() {
 	std::filesystem::path currentPath = std::filesystem::current_path();
-	const char* githubPaths[12] = {
+	const char* githubPaths[13] = {
 		"https://github.com/CS2-OOF-LV/CS2-Client/raw/main/Mod%20Loading%20Files/game/csgo_mods/pak01_000.vpk",
 		"https://github.com/CS2-OOF-LV/CS2-Client/raw/main/Mod%20Loading%20Files/game/csgo_mods/pak01_001.vpk",
 		"https://github.com/CS2-OOF-LV/CS2-Client/raw/main/Mod%20Loading%20Files/game/csgo_mods/pak01_002.vpk",
 		"https://github.com/CS2-OOF-LV/CS2-Client/raw/main/Mod%20Loading%20Files/game/csgo_mods/pak01_003.vpk",
 		"https://github.com/CS2-OOF-LV/CS2-Client/raw/main/Mod%20Loading%20Files/game/csgo_mods/pak01_dir.vpk",
+		"https://github.com/CS2-OOF-LV/CS2-Client/raw/main/Mod%20Loading%20Files/game/bin/win64/vscript.dll",
 		"https://raw.githubusercontent.com/CS2-OOF-LV/CS2-Client/main/Mod%20Loading%20Files/game/csgo/gameinfo.gi",
 		"https://raw.githubusercontent.com/CS2-OOF-LV/CS2-Client/main/Mod%20Loading%20Files/game/csgo/scripts/vscripts/banList.lua",
 		"https://github.com/CS2-OOF-LV/CS2-Client/raw/main/Mod%20Loading%20Files/Start%20Game%20(English)%20-%20DEBUG.bat",
@@ -255,12 +256,13 @@ void Downloader::DownloadMods() {
 		"https://github.com/CS2-OOF-LV/CS2-Client/raw/main/Mod%20Loading%20Files/Workshop%20Tools%20-%20RAYTRACING.bat",
 		"https://github.com/CS2-OOF-LV/CS2-Client/raw/main/Mod%20Loading%20Files/Workshop%20Tools.bat" };
 
-	const char* filePaths[12] = {
+	const char* filePaths[13] = {
 		"game\\csgo_mods\\pak01_000.vpk",
 		"game\\csgo_mods\\pak01_001.vpk",
 		"game\\csgo_mods\\pak01_002.vpk",
 		"game\\csgo_mods\\pak01_003.vpk",
 		"game\\csgo_mods\\pak01_dir.vpk",
+		"game\\bin\\win\\vscript.dll"
 		"game\\csgo\\gameinfo.gi",
 		"game\\csgo\\scripts\\vscripts\\banList.lua",
 		"Start Game (English) - DEBUG.bat",
@@ -273,6 +275,7 @@ void Downloader::DownloadMods() {
 	std::filesystem::create_directory(currentPath / "game" / "csgo_mods");
 	std::filesystem::create_directory(currentPath / "game" / "csgo" / "scripts");
 	std::filesystem::create_directory(currentPath / "game" / "csgo" / "scripts" / "vscripts");
+	std::filesystem::create_directory(currentPath / "game" / "bin" / "win64");
 
 	/* download files to specific directories */
 	int maxIndex = sizeof(filePaths) / sizeof(filePaths[0]);

--- a/CS2Installer/download.cpp
+++ b/CS2Installer/download.cpp
@@ -262,7 +262,7 @@ void Downloader::DownloadMods() {
 		"game\\csgo_mods\\pak01_002.vpk",
 		"game\\csgo_mods\\pak01_003.vpk",
 		"game\\csgo_mods\\pak01_dir.vpk",
-		"game\\bin\\win\\vscript.dll"
+		"game\\bin\\win64\\vscript.dll"
 		"game\\csgo\\gameinfo.gi",
 		"game\\csgo\\scripts\\vscripts\\banList.lua",
 		"Start Game (English) - DEBUG.bat",

--- a/CS2Installer/main.cpp
+++ b/CS2Installer/main.cpp
@@ -36,7 +36,6 @@ int main(int argc, char* argv[]) {
 	printf("starting patches...\n");
 	Patcher::PatchClient();
 	Patcher::PatchServer();
-	Patcher::PatchVScript();
 	printf("finished patches.\n");
 	Sleep(1500);
 	printf("starting mod patches...\n");

--- a/CS2Installer/patcher.cpp
+++ b/CS2Installer/patcher.cpp
@@ -41,18 +41,6 @@ bool Patcher::PatchServer() {
     return true;
 }
 
-bool Patcher::PatchVScript() {
-    const char* someCheck[2] = { "\xBE\x01\x00\x00\x00\x2B\xD6\x74\x61\x3B\xD6\x0F\x85\x9B\x03\x00", "\xBE\x02\x00\x00\x00\x2B\xD6\x74\x61\x3B\xD6\x0F\x85\x9B\x03\x00" };
-
-    if (!ReplaceBytes("game/bin/win64/vscript.dll", someCheck[0], someCheck[1])) {
-        printf("failed to patch vscript function\n");
-        return false;
-    }
-
-    //printf("patched vscript function: %s -> %s\n", someCheck[0], someCheck[1]);
-    return true;
-}
-
 void RemoveExistingPatchFiles(const char* path) {
     std::filesystem::path filePath = path;
     if (std::filesystem::exists(filePath)) {
@@ -63,7 +51,6 @@ void RemoveExistingPatchFiles(const char* path) {
 void Patcher::CleanPatchFiles() {
     RemoveExistingPatchFiles("game/csgo/bin/win64/client.dll");
     RemoveExistingPatchFiles("game/csgo/bin/win64/server.dll");
-    RemoveExistingPatchFiles("game/bin/win64/vscript.dll");
 }
 
 bool Patcher::ReplaceBytes(const char* filename, const char* searchPattern, const char* replaceBytes) {

--- a/CS2Installer/patcher.hpp
+++ b/CS2Installer/patcher.hpp
@@ -6,6 +6,5 @@ namespace Patcher {
 	bool ReplaceBytes(const char* filename, const char* searchPattern, const char* replaceBytes);
 	bool PatchClient();
 	bool PatchServer();
-	bool PatchVScript();
 	void CleanPatchFiles();
 }


### PR DESCRIPTION
Due to the vscript.dll patch not working currently and it not getting patched anyway at the moment, we can use a already patched vscript.dll and implement it into the patcher.

NOTE: Didn't tested the changes. @NebeltheCet can you watch over it just incase?

